### PR TITLE
Improve Install UX

### DIFF
--- a/crds/servicebroker.couchbase.com_servicebrokerconfigs.yaml
+++ b/crds/servicebroker.couchbase.com_servicebrokerconfigs.yaml
@@ -8,6 +8,14 @@ metadata:
   creationTimestamp: null
   name: servicebrokerconfigs.servicebroker.couchbase.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="ConfigurationValid")].status
+    description: whether the configuration is valid
+    name: valid
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: servicebroker.couchbase.com
   names:
     kind: ServiceBrokerConfig
@@ -15,6 +23,7 @@ spec:
     plural: servicebrokerconfigs
     singular: servicebrokerconfig
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/documentation/modules/ROOT/pages/install/kubernetes.adoc
+++ b/documentation/modules/ROOT/pages/install/kubernetes.adoc
@@ -104,14 +104,17 @@ deployment.extensions/couchbase-service-broker condition met
 ====
 The Service Broker does not use a dynamic admission controller to validate the configuration at present.
 It does, however, perform validation internally and report this back to the user through a status in the configuration resource.
-If for any reason the deployment does not become ready, first check the logs for information:
+If you have made a configuration error, the Service Broker `Deployment` will not become ready.
+You can see the validation status directly through the CLI:
 
 [source,console]
 ----
-$ kubectl logs -f deployment/couchbase-service-broker
+$ kubectl get servicebrokerconfigs
+NAME                       VALID   AGE
+couchbase-service-broker   True    9m
 ----
 
-If the logs indicate you have a configuration error you can examine this in more detail with the following command:
+If you have a configuration error, you can examine this in more detail with the following command:
 
 [source,console]
 ----
@@ -119,7 +122,7 @@ $ kubectl describe servicebrokerconfigs
 Status:
   Conditions:
     Last Transition Time:  2020-04-06T15:51:17Z
-    Message:               template couchbase-operator-rolebinding referenced by configuration couchbase-developer-private service instance must exist
+    Message:               template 'couchbase-operator-rolebinding', referenced by binding 'couchbase-developer-private' service instance, must exist
     Reason:                ValidationFailed
     Status:                False
     Type:                  ConfigurationValid

--- a/pkg/apis/servicebroker/v1alpha1/types.go
+++ b/pkg/apis/servicebroker/v1alpha1/types.go
@@ -34,6 +34,8 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories=all;couchbase
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:printcolumn:name="valid",type="string",JSONPath=".status.conditions[?(@.type==\"ConfigurationValid\")].status",description="whether the configuration is valid"
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 type ServiceBrokerConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -51,7 +51,7 @@ func validate(config *v1.ServiceBrokerConfig) error {
 			// Each service plan must have a service binding.
 			binding := getBindingForServicePlan(config, service.Name, plan.Name)
 			if binding == nil {
-				return fmt.Errorf("service plan %s for offering %s does not have a configuration binding", plan.Name, service.Name)
+				return fmt.Errorf("service plan '%s' for offering '%s' does not have a binding", plan.Name, service.Name)
 			}
 
 			// Only bindable service plans may have templates for bindings.
@@ -61,11 +61,11 @@ func validate(config *v1.ServiceBrokerConfig) error {
 			}
 
 			if !bindable && binding.ServiceBinding != nil {
-				return fmt.Errorf("service plan %s for offering %s not bindable, but configuration binding %s defines service binding configuarion", plan.Name, service.Name, binding.Name)
+				return fmt.Errorf("service plan '%s' for offering '%s' not bindable, but binding '%s' defines service binding configuarion", plan.Name, service.Name, binding.Name)
 			}
 
 			if bindable && binding.ServiceBinding == nil {
-				return fmt.Errorf("service plan %s for offering %s bindable, but configuration binding %s does not define service binding configuarion", plan.Name, service.Name, binding.Name)
+				return fmt.Errorf("service plan '%s' for offering '%s' bindable, but binding '%s' does not define service binding configuarion", plan.Name, service.Name, binding.Name)
 			}
 		}
 	}
@@ -74,26 +74,26 @@ func validate(config *v1.ServiceBrokerConfig) error {
 	for _, binding := range config.Spec.Bindings {
 		// Bindings cannot do nothing.
 		if len(binding.ServiceInstance.Registry) == 0 && len(binding.ServiceInstance.Templates) == 0 {
-			return fmt.Errorf("configuration binding %s does nothing for service instances", binding.Name)
+			return fmt.Errorf("binding '%s' does nothing for service instances", binding.Name)
 		}
 
 		if binding.ServiceBinding != nil {
 			if len(binding.ServiceBinding.Registry) == 0 && len(binding.ServiceBinding.Templates) == 0 {
-				return fmt.Errorf("configuration binding %s does nothing for service bindings", binding.Name)
+				return fmt.Errorf("binding '%s' does nothing for service bindings", binding.Name)
 			}
 		}
 
 		// Binding templates must exist.
 		for _, template := range binding.ServiceInstance.Templates {
 			if getTemplateByName(config, template) == nil {
-				return fmt.Errorf("template %s referenced by configuration %s service instance must exist", template, binding.Name)
+				return fmt.Errorf("template '%s', referenced by binding '%s' service instance, must exist", template, binding.Name)
 			}
 		}
 
 		if binding.ServiceBinding != nil {
 			for _, template := range binding.ServiceBinding.Templates {
 				if getTemplateByName(config, template) == nil {
-					return fmt.Errorf("template %s referenced by configuration %s service binding must exist", template, binding.Name)
+					return fmt.Errorf("template '%s', referenced by binding '%s' service binding, must exist", template, binding.Name)
 				}
 			}
 		}


### PR DESCRIPTION
We can use additional printer columns in the CRD to report configuration
status is a more user friendly way than trawling though description
YAML.  Also noticed that the error strings are somewhat clunky and
abigouous so have cleaned these up too.