### PR TITLE
add entrypoint to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM scratch
 
-ADD build/bin/broker /usr/local/bin/
+ADD build/bin/broker /usr/local/bin/broker
+
+ENTRYPOINT ["/usr/local/bin/broker"]

--- a/examples/broker.yaml
+++ b/examples/broker.yaml
@@ -60,8 +60,6 @@ spec:
         - /var/run/secrets/couchbase-service-broker/tls-certificate
         - -tls-private-key
         - /var/run/secrets/couchbase-service-broker/tls-private-key
-        command:
-        - /usr/local/bin/broker
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
This PR will add the binary (the only file in the image) as the entrypoint to the Dockerfile so it is not necessary to specify the command when running it.

`docker run --rm -it couchbase-service-broker:latest -logtostderr -token /token -tls-certificate /tls.crt -tls-private-key /tls.key`