### PR TITLE
Update official service catalog installation URL

### DIFF
--- a/documentation/modules/ROOT/pages/install/prerequisites.adoc
+++ b/documentation/modules/ROOT/pages/install/prerequisites.adoc
@@ -25,7 +25,7 @@ In general, any Kubernetes distribution based on a supported version should work
 
 The Service Broker is recommended for use with the https://kubernetes.io/docs/concepts/extend-kubernetes/service-catalog/[Kubernetes Service Catalog^].
 
-Installation instructions can be found in the https://svc-cat.io/docs/install/[official documentation].
+Installation instructions can be found in the https://kubernetes.io/docs/tasks/service-catalog/[official documentation].
 
 As the Service Broker is standards based, any version of the Service Catalog supporting the Open Service Broker API version 2.13 is supported.
 


### PR DESCRIPTION
Changed the installation URL to a seemingly more authoritative location.

The svc-cat.io site seems to have only pointers to the old helm 2 method.  The kubernetes.io 
site seems to have both helm 2 and 3 and another "sc" tool that worked out quite well.

