### PR TITLE
Fix Error Handling of Service Binding

### DIFF
--- a/test/unit/fixtures/fixtures.go
+++ b/test/unit/fixtures/fixtures.go
@@ -92,6 +92,10 @@ var (
 		},
 	}
 
+	// IllegalTemplateName refers to a template for a non-existent resource
+	// type that can be used to simulate Kubernetes errors.
+	IllegalTemplateName = "illegal"
+
 	// basicConfiguration is the absolute minimum valid configuration allowed by the
 	// service broker configuration schema.
 	basicConfiguration = &v1.ServiceBrokerConfigSpec{
@@ -138,6 +142,12 @@ var (
 				Name:      "test-singleton",
 				Singleton: true,
 				Template:  &runtime.RawExtension{Raw: []byte(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":"singleton"}}`)},
+			},
+			{
+				Name: IllegalTemplateName,
+				Template: &runtime.RawExtension{
+					Raw: []byte(`{"apiVersion":"acme.corp/v1","kind":"RoadRunner","metadata":{"name":"meep-meep"}}`),
+				},
 			},
 		},
 		Bindings: []v1.ConfigurationBinding{

--- a/test/unit/servicebinding_test.go
+++ b/test/unit/servicebinding_test.go
@@ -210,6 +210,22 @@ func TestServiceBindingCreateWithRequiredSchemaNoParameters(t *testing.T) {
 	util.MustPutAndError(t, util.ServiceBindingURI(fixtures.ServiceInstanceName, fixtures.ServiceBindingName, nil), http.StatusBadRequest, binding, api.ErrorValidationError)
 }
 
+// TestServiceBindingIllegalResource tests that the error handling for a failed service
+// instance creation happens gracefully.
+func TestServiceBindingIllegalResource(t *testing.T) {
+	defer mustReset(t)
+
+	configuration := fixtures.BasicConfiguration()
+	configuration.Bindings[0].ServiceBinding.Templates = []string{fixtures.IllegalTemplateName}
+	util.MustReplaceBrokerConfig(t, clients, configuration)
+
+	req := fixtures.BasicServiceInstanceCreateRequest()
+	util.MustCreateServiceInstanceSuccessfully(t, fixtures.ServiceInstanceName, req)
+
+	binding := fixtures.BasicServiceBindingCreateRequest()
+	util.MustPutAndError(t, util.ServiceBindingURI(fixtures.ServiceInstanceName, fixtures.ServiceBindingName, nil), http.StatusBadRequest, binding, api.ErrorConfigurationError)
+}
+
 // TestServiceBindingRereateAfterCreation tests service binding recreation executes successfully when
 // a service binding already exists.
 func TestServiceBindingRecreateAfterCreation(t *testing.T) {


### PR DESCRIPTION
Fixes #31.  We were not checking the operation status of the service
binding creation request, so always returning 201.  While it doesn't fix
the requested issue, it gives visibility.