### PR TITLE
Refresh REST Mapper Cache

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -8,6 +8,7 @@ relfileprefix
 png
 Kubernetes
 kubernetes
+CRD
 CRDs
 adoc
 api

--- a/documentation/modules/ROOT/pages/install/kubernetes.adoc
+++ b/documentation/modules/ROOT/pages/install/kubernetes.adoc
@@ -56,6 +56,9 @@ Use of the Couchbase Autonomous Operator is governed by the https://www.couchbas
 The Couchbase Server configuration requires the installation of custom resource definitions, and a dynamic admission controller to provide defaults to custom resource attributes.
 The Service Broker examples use a namespace-scoped role and cannot create the cluster-scoped resources required.
 You will need to manually https://docs.couchbase.com/operator/2.0/install-kubernetes.html[install the CRDs and dynamic admission controller^] before proceeding.
+
+CRDs should be installed before the Service Broker is started in order to correctly cache any required resource types from the Kubernetes discovery API.
+The Kubernetes discovery API will, however, be polled on a regular basis to refresh this cache and register CRD addition, update or deletion during the Service Broker lifetime.
 ====
 
 == Install the Service Broker Service


### PR DESCRIPTION
We acknowledge that the discovery API is a very expensive call so cache
it for the lifetime of the service broker in order to be a good citizen.
However this doesn't handle users adding CRDs after the service broker
has been started (or updating and deleting for that matter).  By adding
a regular cache refresh we are still playing nice but also handling
these race conditions.  We could do this using CRD events with a watch
stream, but that would suddenly require a ClusterRoleBinding which is an
unacceptable privilege escalation that would be a barrier to entry.

Implements #29 and #30.