### PR TITLE
add instances_retrievable and bindings_retrievable to service catalog configuration

### DIFF
--- a/crds/servicebroker.couchbase.com_servicebrokerconfigs.yaml
+++ b/crds/servicebroker.couchbase.com_servicebrokerconfigs.yaml
@@ -255,6 +255,16 @@ spec:
                           Service Plans can override this field (see Service Plan
                           Object).
                         type: boolean
+                      instancesRetrievable:
+                        description:
+                          Specifies whether the Fetching a Service Instance endpoint
+                          is supported for all Service Plans.
+                        type: boolean
+                      bindingsRetrievable:
+                        description:
+                          Specifies whether the Fetching a Service Binding endpoint
+                          is supported for all Service Plans.
+                        type: boolean
                       dashboardClient:
                         description: Dashboard is a Cloud Foundry extension described
                           in Catalog Extensions. Contains the data necessary to activate

--- a/pkg/apis/servicebroker/v1alpha1/types.go
+++ b/pkg/apis/servicebroker/v1alpha1/types.go
@@ -101,6 +101,14 @@ type ServiceOffering struct {
 	// this field (see Service Plan Object).
 	Bindable bool `json:"bindable"`
 
+	// InstancesRetrievable specifies whether the Fetching a Service Instance endpoint is supported
+	// for all Service Plans.
+	InstancesRetrievable bool `json:"instancesRetrievable,omitempty"`
+
+	// BindingsRetrievable specifies whether the Fetching a Service Binding endpoint is supported
+	// for all Service Plans.
+	BindingsRetrievable bool `json:"bindingsRetrievable,omitempty"`
+
 	// Metadata is an opaque object of metadata for a Service Offering. It is expected that Platforms will
 	// treat this as a blob. Note that there are conventions in existing Service Brokers and Platforms for
 	// fields that aid in the display of catalog data.


### PR DESCRIPTION
Since the broker actually supports fetching instance and binding parameters it should also allow to communicate that to the outside world.

Otherwise `cf curl /v2/service_instances/:instance-id/parameters` does not work because CF is thinking that it is not supported.