### PR TITLE
Update Documentation for 0.0.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: couchbase/service-broker
         tag_with_ref: true
+        tags: latest
     # Install debhelper as it's not there by default, rpm is.
     - name: Install Packages
       run: |

--- a/documentation/modules/ROOT/pages/install/kubernetes.adoc
+++ b/documentation/modules/ROOT/pages/install/kubernetes.adoc
@@ -63,7 +63,12 @@ The Kubernetes discovery API will, however, be polled on a regular basis to refr
 
 == Install the Service Broker Service
 
-The Service Broker is installed with a single configuration file:
+The Service Broker is installed with a single configuration file.
+By default, this will use the `latest` official Docker Hub image.
+If you want to use a specific version, first download the file then edit the image tag in the `Deployment` resource.
+Likewise, if you are using a non-standard container image name you will have to perform the same modifications.
+
+To install the Service Broker run the following:
 
 [source,console]
 ----
@@ -78,12 +83,6 @@ service/couchbase-service-broker created
 The `ServiceAccount` the Service Broker runs as is bound to the `Role` we created in the previous step.
 A `Secret` contains the TLS configuration and bearer token for authentication as the Service Broker is secure by default.
 The `Deployment` creates the Service Broker and ensures it is highly available and a `Service` makes it discoverable by the Kubernetes Service Catalog in the next step.
-
-.Using Non-Standard Container Image Names
-[NOTE]
-====
-Is you are using a non-standard container image name or container registry, you will need to download and edit the `Deployment` to reference your image before creating in Kubernetes.
-====
 
 As it is a regular deployment with a readiness probe, you can check that the Service Broker is up and running with the following command:
 

--- a/documentation/modules/ROOT/pages/install/packages.adoc
+++ b/documentation/modules/ROOT/pages/install/packages.adoc
@@ -8,6 +8,15 @@ ifdef::env-github[]
 :imagesdir: https://github.com/couchbase/service-broker/raw/master/documentation/modules/ROOT/assets/images
 endif::[]
 
+== Official Images
+
+Official Docker images are built automatically per-release.
+Images can be found on https://hub.docker.com/r/couchbase/service-broker[Docker Hub^].
+Take a note of the Docker tag you wish to use--we recommend the latest as it contains all the latest bug fixes and features.
+
+If you want to download the official packages and build your own container images, keep reading.
+Otherwise, skip ahead to xref:install/kubernetes.adoc[Creating the Service Broker Service].
+
 == Official Packages
 
 Official packages are automatically built by the Continuous Integration system.


### PR DESCRIPTION
This release will be the first to create official images, so create a
short cut in the docs for regular users who are not interested in
building their own images.  Also add a latest tag so that the default
configuration just works.

Implements #41