### PR TITLE
Update template-functions.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/reference/template-functions.adoc
+++ b/documentation/modules/ROOT/pages/reference/template-functions.adoc
@@ -209,7 +209,7 @@ Certificates specified without a CA will be self-signed, rather than signed by t
 
 [source]
 ----
-{{ generateCertificate (registry "key.pem") "My CA" "30d" "CA" nil nil nil }}
+{{ generateCertificate (registry "key.pem") "My CA" "720h" "CA" nil nil nil }}
 ----
 
 === Arguments

--- a/documentation/modules/ROOT/pages/reference/template-functions.adoc
+++ b/documentation/modules/ROOT/pages/reference/template-functions.adoc
@@ -209,7 +209,7 @@ Certificates specified without a CA will be self-signed, rather than signed by t
 
 [source]
 ----
-{{ generateCertifcate (registry "key.pem") "My CA" "30d" "CA" nil nil nil }}
+{{ generateCertificate (registry "key.pem") "My CA" "30d" "CA" nil nil nil }}
 ----
 
 === Arguments

--- a/documentation/modules/ROOT/pages/reference/template-functions.adoc
+++ b/documentation/modules/ROOT/pages/reference/template-functions.adoc
@@ -209,7 +209,7 @@ Certificates specified without a CA will be self-signed, rather than signed by t
 
 [source]
 ----
-{{ genetateCertifcate (registry "key.pem") "My CA" "30d" "CA" nil nil nil }}
+{{ generateCertifcate (registry "key.pem") "My CA" "30d" "CA" nil nil nil }}
 ----
 
 === Arguments


### PR DESCRIPTION
Typo in `generateCertifcate` and "d" is not a valid unit (see https://golang.org/pkg/time/#ParseDuration)