### PR TITLE
Update Testing Matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,9 +57,9 @@ jobs:
     strategy:
       matrix:
         versions:
-        - v1.17.11
         - v1.18.8
         - v1.19.1
+        - v1.20.0
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/documentation/modules/ROOT/pages/install/prerequisites.adoc
+++ b/documentation/modules/ROOT/pages/install/prerequisites.adoc
@@ -21,6 +21,12 @@ The following platforms are supported:
 
 In general, any Kubernetes distribution based on a supported version should work.
 
+[IMPORTANT]
+====
+Only in-support versions of Kubernetes will be tested (versions currently remain supported for 1 year).
+There are no guarantees older versions of Kubernetes will work.
+====
+
 === Service Catalog
 
 The Service Broker is recommended for use with the https://kubernetes.io/docs/concepts/extend-kubernetes/service-catalog/[Kubernetes Service Catalog^].


### PR DESCRIPTION
1.20 was released in December, 1.17 goes out of support on 30/1/21.