### PR TITLE
Polling Delete Return Type

### DIFF
--- a/pkg/broker/handlers.go
+++ b/pkg/broker/handlers.go
@@ -651,7 +651,7 @@ func handlePollServiceInstance(w http.ResponseWriter, r *http.Request, params ht
 	}
 
 	if !entry.Exists() {
-		jsonError(w, errors.NewResourceGoneError("service instance does not exist"))
+		JSONResponse(w, http.StatusGone, struct{}{})
 		return
 	}
 

--- a/test/unit/util/api.go
+++ b/test/unit/util/api.go
@@ -568,14 +568,14 @@ func MustDeleteServiceInstance(t *testing.T, name string, req *api.CreateService
 func MustPollServiceInstanceForDeletion(t *testing.T, name string, rsp *api.CreateServiceInstanceResponse) {
 	callback := func() error {
 		// When polling for deletion, it will start as OK (as per MustPollServiceInstanceForCompletion)
-		// however will finally respond with Gone.
-		apiError := &api.Error{}
-		if err := Get(ServiceInstancePollURI(name, PollServiceInstanceQuery(nil, rsp)), http.StatusGone, apiError); err != nil {
+		// however will finally respond with Gone.  When it does, assert the response is an empty object.
+		var response map[string]interface{}
+
+		if err := Get(ServiceInstancePollURI(name, PollServiceInstanceQuery(nil, rsp)), http.StatusGone, &response); err != nil {
 			return err
 		}
 
-		// Assert that the correct error message is given.
-		Assert(t, apiError.Error == api.ErrorResourceGone)
+		Assert(t, len(response) == 0)
 
 		return nil
 	}


### PR DESCRIPTION
When this responds with GONE, then it should return an empty object, not
an error message.

Implements #49