### PR TITLE
Update Build and Test

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Configure Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.13.3'
+        go-version: '^1.16.3'
     - name: Build
       run: make
   test:
@@ -41,7 +41,7 @@ jobs:
     - name: Configure Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.13.3'
+        go-version: '^1.16.3'
     - name: Test
       run: make test
     - name: Make Code Coverage
@@ -60,6 +60,7 @@ jobs:
         - v1.18.8
         - v1.19.1
         - v1.20.0
+        - v1.21.1
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -68,10 +69,11 @@ jobs:
     - name: Configure Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.13.3'
+        go-version: '^1.16.3'
     - name: Setup Kind
       uses: engineerd/setup-kind@v0.5.0
       with:
+        version: v0.11.0
         image: kindest/node:${{ matrix.versions }}
     - name: Build Images
       run: |
@@ -95,7 +97,7 @@ jobs:
     - name: Configure Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.13.3'
+        go-version: '^1.16.3'
     - name: Build Archives
       run: make archive -e DESTDIR=/tmp/archive
   docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Configure Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.13.3'
+        go-version: '^1.16.3'
     # The release is triggered by pushing an annotated tag to the repository.
     # First step is to extract the versioning information and make it available
     # for other steps in the build pipeline.


### PR DESCRIPTION
Bump the Go toolchain to 3.16 and add support for Kind 0.11 and
Kubernetes 1.21.